### PR TITLE
Upstreaming changes required by the Winit keyboard rework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ edition = "2018"
 travis-ci = { repository = "francesca64/xkbcommon-dl" }
 
 [dependencies]
-dlib = "0.4"
+dlib = "0.5"
 lazy_static = "1.0"
 bitflags = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ repository = "https://github.com/francesca64/xkbcommon-dl"
 authors = ["Francesca Frangipane <francesca@comfysoft.net>"]
 license = "MIT"
 description = "Dynamically loaded xkbcommon and xkbcommon-x11 Rust bindings."
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "francesca64/xkbcommon-dl" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ edition = "2018"
 [badges]
 travis-ci = { repository = "francesca64/xkbcommon-dl" }
 
+[features]
+x11 = []
+
 [dependencies]
 dlib = "0.5"
 lazy_static = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ x11 = []
 dlib = "0.5"
 lazy_static = "1.0"
 bitflags = "1.0"
+log = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,9 @@ use lazy_static::lazy_static;
 use bitflags::bitflags;
 
 pub mod keysyms;
-mod x11;
-pub use self::x11::*;
+
+#[cfg(feature = "x11")]
+pub mod x11;
 
 use std::os::raw::{c_char, c_int, c_uint, c_void};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,13 +279,13 @@ functions:
 
 lazy_static!(
     pub static ref XKBCOMMON_OPTION: Option<XkbCommon> = {
-        XkbCommon::open("libxkbcommon.so").ok()
+        unsafe { XkbCommon::open("libxkbcommon.so") }.ok()
     };
     pub static ref XKBCOMMON_HANDLE: &'static XkbCommon = {
         XKBCOMMON_OPTION.as_ref().expect("Library libxkbcommon.so could not be loaded.")
     };
     pub static ref XKBCOMMON_COMPOSE_OPTION: Option<XkbCommonCompose> = {
-        XkbCommonCompose::open("libxkbcommon.so").ok()
+        unsafe { XkbCommonCompose::open("libxkbcommon.so") }.ok()
     };
     pub static ref XKBCOMMON_COMPOSE_HANDLE: &'static XkbCommonCompose = {
         XKBCOMMON_COMPOSE_OPTION.as_ref().expect("Could not load compose module from libxkbcommon.so.")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,9 @@
 #![allow(dead_code, non_camel_case_types)]
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
-#[macro_use]
-extern crate dlib;
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate bitflags;
+use dlib::dlopen_external_library;
+use lazy_static::lazy_static;
+use bitflags::bitflags;
 
 pub mod keysyms;
 mod x11;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub type xkb_mod_index_t = u32;
 pub type xkb_mod_mask_t = u32;
 pub type xkb_led_index_t = u32;
 pub type xkb_led_mask_t = u32;
+pub type xkb_keymap_key_iter_t = Option<extern "C" fn(*mut xkb_keymap, xkb_keycode_t, *mut c_void)>;
 
 pub const XKB_KEYCODE_INVALID :u32 = 0xffffffff;
 pub const XKB_LAYOUT_INVALID  :u32 = 0xffffffff;
@@ -221,6 +222,9 @@ functions:
     fn xkb_keymap_ref(*mut xkb_keymap) -> *mut xkb_keymap,
     fn xkb_keymap_unref(*mut xkb_keymap) -> (),
     fn xkb_keymap_get_as_string(*mut xkb_keymap, xkb_keymap_format) -> *const c_char,
+
+    fn xkb_keymap_key_get_syms_by_level(*mut xkb_keymap, xkb_keycode_t, xkb_layout_index_t, xkb_level_index_t, *mut *const xkb_keysym_t) -> c_int,
+    fn xkb_keymap_key_repeats(*mut xkb_keymap, xkb_keycode_t) -> c_int,
 
     fn xkb_state_new(*mut xkb_keymap) -> *mut xkb_state,
     fn xkb_state_ref(*mut xkb_state) -> *mut xkb_state,

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -42,7 +42,7 @@ functions:
 
 lazy_static!(
     pub static ref XKBCOMMON_X11_OPTION: Option<XkbCommonX11> = {
-        XkbCommonX11::open("libxkbcommon-x11.so").ok()
+        unsafe { XkbCommonX11::open("libxkbcommon-x11.so").ok() }
     };
     pub static ref XKBCOMMON_X11_HANDLE: &'static XkbCommonX11 = {
         XKBCOMMON_X11_OPTION.as_ref().expect("Library libxkbcommon-x11.so could not be loaded.")

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -1,5 +1,6 @@
 use std::os::raw::c_int;
 
+use dlib::DlError::CantOpen;
 pub type xcb_connection_t = c_void;
 
 use super::*;
@@ -42,9 +43,15 @@ functions:
 
 lazy_static!(
     pub static ref XKBCOMMON_X11_OPTION: Option<XkbCommonX11> = {
-        unsafe { XkbCommonX11::open("libxkbcommon-x11.so").ok() }
+        open_with_sonames(
+            &["libxkbcommon-x11.so", "libxkbcommon-x11.so.0"],
+            None,
+            |name| unsafe { XkbCommonX11::open(name) },
+        )
     };
     pub static ref XKBCOMMON_X11_HANDLE: &'static XkbCommonX11 = {
-        XKBCOMMON_X11_OPTION.as_ref().expect("Library libxkbcommon-x11.so could not be loaded.")
+        XKBCOMMON_X11_OPTION
+            .as_ref()
+            .expect("Library libxkbcommon-x11.so could not be loaded.")
     };
 );


### PR DESCRIPTION
If you want me to split this out into separate PRs per logical change, I can do that, but each commit here should hopefully be self-contained. Of all these changes, the only one that's probably *technically* necessary is the one adding a couple of functions and a type alias. The changes required for some older versions of Ubuntu might also benefit from some de-duplication, but I've refrained from doing that for now.