### PR TITLE
Don't expose `once_cell` publically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ x11 = []
 
 [dependencies]
 bitflags = "2.3.1"
-dlib = "0.5"
+dlib = "0.5.2"
 log = "0.4"
 once_cell = "1.17"


### PR DESCRIPTION
Fixes #12.

r @notgull

--

I wasn't sure why I needed a dlib update in the first place though.