### PR TITLE
Load sonames first

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,7 @@ pub fn xkbcommon_option() -> Option<&'static XkbCommon> {
     XKBCOMMON_OPTION
         .get_or_init(|| {
             open_with_sonames(
-                &["libxkbcommon.so", "libxkbcommon.so.0"],
+                &["libxkbcommon.so.0", "libxkbcommon.so"],
                 None,
                 |name| unsafe { XkbCommon::open(name) },
             )
@@ -322,7 +322,7 @@ pub fn xkbcommon_compose_option() -> Option<&'static XkbCommonCompose> {
     XKBCOMMON_COMPOSE_OPTION
         .get_or_init(|| {
             open_with_sonames(
-                &["libxkbcommon.so", "libxkbcommon.so.0"],
+                &["libxkbcommon.so.0", "libxkbcommon.so"],
                 Some("compose"),
                 |name| unsafe { XkbCommonCompose::open(name) },
             )

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -47,7 +47,7 @@ pub fn xkbcommon_x11_option() -> Option<&'static XkbCommonX11> {
     XKBCOMMON_X11_OPTION
         .get_or_init(|| {
             open_with_sonames(
-                &["libxkbcommon-x11.so", "libxkbcommon-x11.so.0"],
+                &["libxkbcommon-x11.so.0", "libxkbcommon-x11.so"],
                 None,
                 |name| unsafe { XkbCommonX11::open(name) },
             )


### PR DESCRIPTION
The full soname, with the version number of the so file should be tried before the one without a version number.

If this is not done, the latest version, which probably is no longer compatible, might be used instead of the version that the library was compiled against and cause problems.

The previous behaviour was also problematic when trying to create a classic mode snap for Neovide. `libxkbcommon.so` is not installed unless you install the dev package. So then it's not found in the snap itself, but might be found on the host and loaded from there, which can cause problems. When using the full version `libxkbcommon.so.0` it's found inside the snap and loaded from there as it should. I believe this issue also affects the current snap package of Alacritty for example, but I have not verified.

I also verified that the `x11-rs` library does it correctly and loads the versioned so file first https://github.com/AltF02/x11-rs/blob/fced94ef6eb5935c892079a46812806f7b7a9237/src/xlib.rs#L25.

It would be nice to get a patch release with this fix, so I can complete the snap support for Neovide.
